### PR TITLE
updated module name so it does not fail when using the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
     "trailingComma": "es5"
   },
   "author": "Deeksha Sharma",
-  "module": "dist/ui.esm.js",
+  "module": "dist/design-system.esm.js",
   "private": false,
   "size-limit": [
     {
-      "path": "dist/ui.cjs.production.min.js",
+      "path": "dist/design-system.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/ui.esm.js",
+      "path": "dist/design-system.esm.js",
       "limit": "10 KB"
     }
   ],


### PR DESCRIPTION
# Issue
When installing the library, it could not be used because a file was not found. This is because the name of the module was incorrect.

# Implementation
Update the module name on the `/dist` directory